### PR TITLE
fix foreign keys delete for newer version of MySQL

### DIFF
--- a/includes/module/tasks/type/class-fw-ext-backups-task-type-db-restore.php
+++ b/includes/module/tasks/type/class-fw-ext-backups-task-type-db-restore.php
@@ -1211,6 +1211,9 @@ class FW_Ext_Backups_Task_Type_DB_Restore extends FW_Ext_Backups_Task_Type {
 					if ( false !== array_search( $foreign['referenced_table_name'], $drop_sql ) ) {
 						$wpdb->query( "ALTER TABLE {$foreign['table_name']} DROP FOREIGN KEY {$foreign['constraint_name']}" );
 					}
+					if ( false !== array_search( $foreign['REFERENCED_TABLE_NAME'], $drop_sql ) ) {
+						$wpdb->query( "ALTER TABLE {$foreign['TABLE_NAME']} DROP FOREIGN KEY {$foreign['CONSTRAINT_NAME']}" );
+					}
 				}
 
 				$drop_sql = "DROP TABLE \n". implode(" , \n", $drop_sql);


### PR DESCRIPTION
Array now has uppercased keys:

  array (
    'CONSTRAINT_NAME' => 'fk_wp_wc_download_log_permission_id',
    'COLUMN_NAME' => 'permission_id',
    'REFERENCED_TABLE_NAME' => 'wp_woocommerce_downloadable_product_permissions',
    'REFERENCED_COLUMN_NAME' => 'permission_id',
    'TABLE_NAME' => 'wp_wc_download_log',
  ),