### PR TITLE
Fix php8 required parameter $zip_path follows optional parameter

### DIFF
--- a/includes/module/tasks/class--fw-ext-backups-module-tasks.php
+++ b/includes/module/tasks/class--fw-ext-backups-module-tasks.php
@@ -982,7 +982,7 @@ class _FW_Ext_Backups_Module_Tasks extends _FW_Ext_Backups_Module {
 	 * @param string $zip_path
 	 * @param array $filesystem_args {}|{hostname: '', username: '', password: '', connection_type: ''}
 	 */
-	public function do_restore($full = false, $zip_path, $filesystem_args = array()) {
+	public function do_restore($full, $zip_path, $filesystem_args = array()) {
 		$tmp_dir = self::backups()->get_tmp_dir();
 		$id_prefix = 'restore:';
 


### PR DESCRIPTION
Fix Deprecated: Required parameter $zip_path follows optional parameter $full in /wp-content/plugins/unyson/framework/extensions/backups/includes/module/tasks/class--fw-ext-backups-module-tasks.php on line 985 warning on php 8 version.

Since the `$full` argument is passed in every call, we don't need a default value, so we can remove it and thus we can fix the deprecated warning.