### PR TITLE
PHP 8.1 sizes generate issue with array merge

### DIFF
--- a/includes/module/tasks/type/class-fw-ext-backups-task-type-image-sizes-restore.php
+++ b/includes/module/tasks/type/class-fw-ext-backups-task-type-image-sizes-restore.php
@@ -118,7 +118,9 @@ class FW_Ext_Backups_Task_Type_Image_Sizes_Restore extends FW_Ext_Backups_Task_T
 						remove_filter('intermediate_image_sizes', array($this, '_filter_image_sizes'));
 					}
 
-					$state['processed_sizes'] = array_merge($state['processed_sizes'], $meta['sizes']);
+					if(!empty($state['processed_sizes']) && !empty($meta['sizes'])){
+						$state['processed_sizes'] = array_merge($state['processed_sizes'], $meta['sizes']);
+					}
 				}
 
 				if (isset($meta)) {


### PR DESCRIPTION
Hello @ViorelEremia 

I hope you are doing well

We are a theme developer and have been working with Unyson and its demo content importer for a couple of years. PHP 7.4 is deprecated on many servers. Our many customers, facing issues with demo content import. This is not a big issue but stopping our customers to import demo content. We just got fixed that by adding a line of code. If you could add that fix quickly that would be much appreciated 

![8 1](https://user-images.githubusercontent.com/108173755/207025112-195c5727-30d4-4534-a64c-233967dcd61b.png)

This is fix 
![ext-8 1](https://user-images.githubusercontent.com/108173755/207025149-79df2421-60ee-41f8-b439-80f40b4afa90.png)

Replace that line : 

`$state['processed_sizes'] = array_merge($state['processed_sizes'], $meta['sizes']);`

with below 

```
if(!empty($state['processed_sizes']) && !empty($meta['sizes'])){
    $state['processed_sizes'] = array_merge($state['processed_sizes'], $meta['sizes']);
}
```

Looking forward to fixing that asap, that would be much appreciated 

Thank you